### PR TITLE
Allow XHR requests from remote domains

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ APP_SECRET=4501ce61ff46591fa2f11036970164b1
 ###< symfony/framework-bundle ###
 
 ###> nelmio/cors-bundle ###
-CORS_ALLOW_ORIGIN='^https?://localhost(:[0-9]+)?$'
+CORS_ALLOW_ORIGIN=.
 ###< nelmio/cors-bundle ###
 
 ###> custom ###


### PR DESCRIPTION
In the current form the service only allows XHR requests from `localhost` - for reasons unknown.

In order to use the cover service from clientside applications on other domains we need to open up for other domains.

According to CORS the browser must send a preflight `OPTIONS` request to the cover service with a header containing the origin e.g. `Origin: https://aakb.dk`. If the request is allowed the service should respond with a header providing information about the allowed origins e.g. `Access-Control-Allow-Origin: https://aakb.dk` or simply `Access-Control-Allow-Origin: *` to allow all origins.

As far as I can tell in the current form the cover service will only send `Access-Control-Allow-Origin: https://localhost`. This effectively prevents access from all other domains.

![Apps | Checklist - Entry ⋅ Storybook 2020-01-29 05-59-10](https://user-images.githubusercontent.com/73966/73329094-8b513180-425c-11ea-81b6-aeac3b2f0dd4.png)

This change should cause the service to respond with `Access-Control-Allow-Origin: *` which effectively opens up for all domains.

I originally wanted to set the value to `*` but there seems to be problems with this approach when using the Nelmio bundle: https://github.com/nelmio/NelmioCorsBundle/issues/99. According to the comments `.` should work.'

*NB: This is completely untested! It is merely the result of digging around the codebase and googling GitHub issues.*