### PR TITLE
DDBTEAM-396: Added 'CORS_ALLOW_ORIGIN' to k8s configuration.

### DIFF
--- a/infrastructure/docker/cover-service/etc/confd/templates/env.local.tmpl
+++ b/infrastructure/docker/cover-service/etc/confd/templates/env.local.tmpl
@@ -7,6 +7,10 @@ APP_SECRET={{ getenv "APP_SECRET" "MySuperSecret" }}
 APP_ENABLE_NO_HITS={{ getenv "APP_ENABLE_NO_HITS" "true" }}
 ###< custom ###
 
+###> nelmio/cors-bundle ###
+CORS_ALLOW_ORIGIN={{ getenv "APP_CORS_ALLOW_ORIGIN" "'^https?://localhost(:[0-9]+)?$'" }}
+###< nelmio/cors-bundle ###
+
 ###> enqueue/redis ###
 ENQUEUE_DSN=redis://{{ getenv "APP_REDIS_SERVER" "redis" }}:{{ getenv "APP_REDIS_PORT" "6379" }}
 REDIS_CACHE_DSN=redis://{{ getenv "APP_REDIS_CACHE_SERVER" "redis" }}:{{ getenv "APP_REDIS_CACHE_PORT" "6379" }}/{{ getenv "APP_REDIS_CACHE_DB" "10" }}

--- a/infrastructure/k8s/app-deployment.yaml
+++ b/infrastructure/k8s/app-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: cover-service
   name: cover-service-config
 data:
+  APP_CORS_ALLOW_ORIGIN: '*'
   APP_REDIS_SERVER: 'redis'
   APP_REDIS_PORT: '6379'
   APP_REDIS_CACHE_SERVER: 'redis'

--- a/infrastructure/k8s/stg/app-deployment.yaml
+++ b/infrastructure/k8s/stg/app-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: cover-service
   name: cover-service-config
 data:
+  APP_CORS_ALLOW_ORIGIN: '*'
   APP_REDIS_SERVER: 'redis'
   APP_REDIS_PORT: '6379'
   APP_REDIS_CACHE_SERVER: 'redis'


### PR DESCRIPTION
This is based on the work done in https://github.com/danskernesdigitalebibliotek/ddb-cover-service/pull/56

The main different is that it's been moved into the kubernetes configuration so it can be changed later on without doing a release.

Have tested that both '*' and '.' works to allow XHR request from a remote domain.

![Screenshot 2020-01-31 at 10 14 19](https://user-images.githubusercontent.com/111397/73527297-1b38dc00-4413-11ea-917d-d57ea3399b8e.png)

![Screenshot 2020-01-31 at 10 19 28](https://user-images.githubusercontent.com/111397/73527351-36a3e700-4413-11ea-92a8-d165f2b7bfee.png)
